### PR TITLE
#67 | Update Github Actions PHPStan and PHPUnit versions

### DIFF
--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -13,5 +13,5 @@ jobs:
         uses: php-actions/phpstan@v3
         with:
           path: src/
-          version: 1.10.44
+          version: 1.11.5
           php_version: 8.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           bootstrap: vendor/autoload.php
           configuration: phpunit.xml
-          version: 10.4.2
+          version: 11.2.5


### PR DESCRIPTION
# What was changed

I've updated the Github Actions `PHPStan` and `PHPUnit` versions

# Background

It was changed because the CI was using the outdated versions

# How it can be tested

CI

# Keep in mind that...

n/a
