### PR TITLE
#69 | Remove PHPUnit deprecations

### DIFF
--- a/tests/EnumValuesTest.php
+++ b/tests/EnumValuesTest.php
@@ -4,22 +4,24 @@ declare(strict_types=1);
 
 namespace Flashlabs\Enums\Tests;
 
+use Flashlabs\Enums\EnumValues;
 use Flashlabs\Enums\Tests\Data\Backed\IntegersEnum;
 use Flashlabs\Enums\Tests\Data\Backed\StringsEnum;
 use Flashlabs\Enums\Tests\Data\Pure\PureEnum;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers EnumValues
- * @group unit
- */
+#[Group('functional')]
+#[CoversClass(EnumValues::class)]
 final class EnumValuesTest extends TestCase
 {
     /**
-     * @dataProvider enumValuesDataProvider
      * @param array<string|int|null> $values
      * @param array<string|int|null> $expectedValues
      */
+    #[DataProvider('enumValuesDataProvider')]
     public function testEnumValues(array $values, array $expectedValues): void
     {
         self::assertCount(\count($expectedValues), $values);


### PR DESCRIPTION
# What was changed

I've removed the `phpunit` deprecations

# Background

It was changed because of it was causing issues

# How it can be tested

CI

# Keep in mind that...

n/a
